### PR TITLE
Fixed an error with top padding in the component

### DIFF
--- a/src/components/RecipePage/Directions.css
+++ b/src/components/RecipePage/Directions.css
@@ -17,7 +17,6 @@
   border-radius: 5px;
   font-family: "Avengeance";
   font-size: 34pt;
-  margin-top: 20px;
   display: inline-block;
   padding-left: 5px;
   padding-right: 10px;


### PR DESCRIPTION
Nu när alla komponenter kommer på plats, så ser man saker man inte sett tidigare. Jag hade 20px top padding på min box som det står "directions" i, vilket gjorde att den visades ungefär 10 punkter lägre än i Daniel och Arvids komponenter. Fixat.