### PR TITLE
Christian branch

### DIFF
--- a/src/components/ModalSettings/ModalSettings.tsx
+++ b/src/components/ModalSettings/ModalSettings.tsx
@@ -2,36 +2,32 @@ import { useState } from "react";
 import Button from "react-bootstrap/Button";
 import Modal from "react-bootstrap/Modal";
 import { useApiCheckerStore } from "../Stores/checkIfApiExists";
+import { useDeveloperModeStore } from "../../components/Stores/developerMode";
 
 import "./ModalSettings.css";
 
 //@ts-ignore
 export default function ModalSaveAPIKey(props) {
   //@ts-ignore
-  const persistedSettings = JSON.parse(localStorage.getItem("mightySettings"));
+  const devMode: boolean = useDeveloperModeStore((state) => state.devMode);
+
+  //@ts-ignore
+  const persistedSettings = devMode ? JSON.parse(localStorage.getItem("mightySettings")) : JSON.parse(localStorage.getItem("mightyProdSettings"));
 
   //@ts-ignore // global zustand variable/state to set state of api key
   const setApiKey = useApiCheckerStore((state) => state.updateApiKey);
+  //@ts-ignore
+  const setProdApiKey = useApiCheckerStore((state) => state.updateProdApiKey);
+
 
   const [show, setShow] = useState(true);
-  const [apiInputBox, setApiInputBox] = useState(
-    localStorage.getItem("storedApiKey")
-  );
+  const [apiInputBox, setApiInputBox] = useState(devMode ? localStorage.getItem("storedApiKey") : localStorage.getItem("storedProdApiKey"));
   const [maxHits, setMaxHits] = useState(persistedSettings.storedMaxHits);
-  const [maxRandom, setMaxRandom] = useState(
-    persistedSettings.storedMaxRandomHits
-  );
-  const [includeNutrition, setIncludeNutrition] = useState(
-    persistedSettings.storeAddRecipeNutrition
-  );
-  const [ignorePantry, setIgnorePantry] = useState(
-    persistedSettings.storedIgnorePantry
-  );
+  const [maxRandom, setMaxRandom] = useState(persistedSettings.storedMaxRandomHits);
+  const [includeNutrition, setIncludeNutrition] = useState(persistedSettings.storeAddRecipeNutrition);
+  const [ignorePantry, setIgnorePantry] = useState(persistedSettings.storedIgnorePantry);
   const [ranking, setRanking] = useState(persistedSettings.storedRanking);
-
-  const [useStatic, setUseStatic] = useState(
-    localStorage.getItem("mightyRandomOrStatic")
-  );
+  const [useStatic, setUseStatic] = useState(devMode ? localStorage.getItem("mightyRandomOrStatic") : "false");
 
   const handleClose = () => setShow(false);
 
@@ -81,10 +77,16 @@ export default function ModalSaveAPIKey(props) {
     persistedSettings.storedIgnorePantry = ignorePantry;
     persistedSettings.storedRanking = ranking;
 
-    localStorage.setItem("storedApiKey", apiInputBox!);
-    setApiKey(localStorage.getItem("storedApiKey"));
-    localStorage.setItem("mightySettings", JSON.stringify(persistedSettings));
-    localStorage.setItem("mightyRandomOrStatic", useStatic!);
+    if(devMode){
+      localStorage.setItem("storedApiKey", apiInputBox!);
+      setApiKey(localStorage.getItem("storedApiKey"));
+      localStorage.setItem("mightySettings", JSON.stringify(persistedSettings));
+      localStorage.setItem("mightyRandomOrStatic", useStatic!);
+    } else{
+      localStorage.setItem("storedProdApiKey", apiInputBox!);
+      setProdApiKey(localStorage.getItem("storedProdApiKey"));
+      localStorage.setItem("mightyProdSettings", JSON.stringify(persistedSettings));
+    }
 
     handleClose();
   };
@@ -107,17 +109,16 @@ export default function ModalSaveAPIKey(props) {
           <input
             className="input-Modal"
             type="text"
+            placeholder="Enter API key here..."
             value={apiInputBox!}
             onChange={handleApiChange}
           />
-          <input
-            className="input-Checkbox"
-            id="random-static"
-            type="checkbox"
-            checked={useStatic === null || useStatic === "true" ? true : false}
-            onChange={handleStaticChange}
-          />
-          <label htmlFor="random-static">Use static instead of random</label>
+          {devMode &&
+          <>
+            <input className="input-Checkbox" id="random-static" type="checkbox" checked={useStatic === null || useStatic === "true" ? true : false} onChange={handleStaticChange}/>
+            <label htmlFor="random-static">Use static instead of random</label>
+          </>}
+
           <br />
           Max hits on search: {maxHits}
           <input
@@ -137,14 +138,12 @@ export default function ModalSaveAPIKey(props) {
             value={maxRandom}
             onChange={handleMaxRndChange}
           />
-          <input
-            className="input-Checkbox"
-            id="nutrition-check"
-            type="checkbox"
-            checked={includeNutrition}
-            onChange={handleNutritionChange}
-          />
-          <label htmlFor="nutrition-check">Include recipe nutrition</label>
+          {devMode &&
+          <>
+            <input className="input-Checkbox" id="nutrition-check" type="checkbox" checked={includeNutrition} onChange={handleNutritionChange}/>
+            <label htmlFor="nutrition-check">Include recipe nutrition</label>
+          </>}
+
           <br />
           <input
             className="input-Checkbox"

--- a/src/components/Stores/checkIfApiExists.tsx
+++ b/src/components/Stores/checkIfApiExists.tsx
@@ -2,5 +2,7 @@ import { create } from 'zustand'
 
 export const useApiCheckerStore = create((set) => ({
     apiKey: localStorage.getItem("storedApiKey"),
+    apiProdKey: localStorage.getItem("storedProdApiKey"),
     updateApiKey: (newKey: string) => set({apiKey: newKey}),
+    updateProdApiKey: (newKey: string) => set({apiProdKey: newKey}),
 }))

--- a/src/components/Stores/developerMode.tsx
+++ b/src/components/Stores/developerMode.tsx
@@ -1,0 +1,6 @@
+import { create } from 'zustand'
+
+export const useDeveloperModeStore = create((set) => ({
+    devMode: false,
+    setDevMode: (input: boolean) => set({devMode: input}),
+}))

--- a/src/pages/RecipePage/RecipePage.tsx
+++ b/src/pages/RecipePage/RecipePage.tsx
@@ -22,12 +22,16 @@ export const RecipePage = () => {
 //  ***************   |This loads the id to the router via useLoaderData and the loader in the route |***************
   const recipeId = useLoaderData();
   const [recipeData, setRecipeData] = useState(null);
+  const [noResultsReturned, setNoResultsReturned] = useState(false);
+
 
   //@ts-ignore //global zustand variable/state to monitor back button click and persist state.
   const handleBackClick = useBackButtonStore((state) => state.clickBackButton);
 
-    //@ts-ignore
-    const devMode: boolean = useDeveloperModeStore((state) => state.devMode);
+  //@ts-ignore
+  const devMode: boolean = useDeveloperModeStore((state) => state.devMode);
+  //@ts-ignore
+  const apiKey: string | null = devMode ? useApiCheckerStore((state) => state.apiKey) : useApiCheckerStore((state) => state.apiProdKey);
 
   useEffect(() => {
     const persistedSettings = JSON.parse(localStorage.getItem("mightySettings")!);
@@ -38,14 +42,16 @@ export const RecipePage = () => {
 //Remember to put in your own API key here the first time you run this code
 //If you see the middle component of the page saying Loading... then you've probably forgotten to put in your API key
       //@ts-ignore
-      const apiKey: string | null = devMode ? useApiCheckerStore((state) => state.apiKey) : useApiCheckerStore((state) => state.apiProdKey);
+
       const url = `https://api.spoonacular.com/recipes/${recipeId}/information?apiKey=${apiKey}&includeNutrition=${persistedSettings.storeAddRecipeNutrition}`;
 
       fetch(url)
         .then((response) => {
           if (response.ok) {
+            setNoResultsReturned(false)
             return response.json();
           } else {
+            setNoResultsReturned(true)
             throw new Error('Error fetching recipe');
           }
         })
@@ -60,7 +66,11 @@ export const RecipePage = () => {
   }, [recipeId]);
 
   if (!recipeData) {
-    return <div>Fetch unsuccesful, check your API key</div>;
+    if(noResultsReturned){
+      return <div>Fetch unsuccesful, check your API key</div>;
+    }else{
+      return <div>Loading recipe...</div>;
+    }
   }
 
   return (

--- a/src/pages/RecipePage/RecipePage.tsx
+++ b/src/pages/RecipePage/RecipePage.tsx
@@ -6,6 +6,8 @@ import { Directions } from './Directions';
 import { DishImage } from './DishImage';
 import {useLoaderData} from "react-router-dom";
 import {useBackButtonStore} from "../../components/Stores/backButtonClick";
+import { useDeveloperModeStore } from "../../components/Stores/developerMode";
+import { useApiCheckerStore } from "../../components/Stores/checkIfApiExists";
 import './RecipePage.css';
 
 //This function fetches the recipe data from the API and stores it in local storage
@@ -24,6 +26,9 @@ export const RecipePage = () => {
   //@ts-ignore //global zustand variable/state to monitor back button click and persist state.
   const handleBackClick = useBackButtonStore((state) => state.clickBackButton);
 
+    //@ts-ignore
+    const devMode: boolean = useDeveloperModeStore((state) => state.devMode);
+
   useEffect(() => {
     const persistedSettings = JSON.parse(localStorage.getItem("mightySettings")!);
     const storedData = JSON.parse(localStorage.getItem(`recipeFetch_${recipeId}`)!);
@@ -32,7 +37,8 @@ export const RecipePage = () => {
     } else {
 //Remember to put in your own API key here the first time you run this code
 //If you see the middle component of the page saying Loading... then you've probably forgotten to put in your API key
-      const apiKey: string | null = localStorage.getItem("storedApiKey");
+      //@ts-ignore
+      const apiKey: string | null = devMode ? useApiCheckerStore((state) => state.apiKey) : useApiCheckerStore((state) => state.apiProdKey);
       const url = `https://api.spoonacular.com/recipes/${recipeId}/information?apiKey=${apiKey}&includeNutrition=${persistedSettings.storeAddRecipeNutrition}`;
 
       fetch(url)

--- a/src/pages/StartPage/StartPage.tsx
+++ b/src/pages/StartPage/StartPage.tsx
@@ -14,12 +14,24 @@ import { RecipeMTVMH } from "../../components/Interface/Interface";
 import { useMediaQuery } from "../../components/DropdownNav/DropdownNav";
 import { useBackButtonStore } from "../../components/Stores/backButtonClick";
 import { useApiCheckerStore } from "../../components/Stores/checkIfApiExists";
+import { useDeveloperModeStore } from "../../components/Stores/developerMode";
 
 import "./StartPage.css";
 import Sort from "../../components/Sort/Sort";
 
 //@ts-ignore
 export default function StartPage(props) {
+  //@ts-ignore
+  const setDevMode = useDeveloperModeStore((state) => state.setDevMode);
+  setDevMode(true);
+
+  //@ts-ignore
+  const devMode: boolean = useDeveloperModeStore((state) => state.devMode);
+
+  //@ts-ignore
+  const setProdApiKey = useApiCheckerStore((state) => state.updateProdApiKey);
+
+
   // Below 2 arrays are used to make it clear for TypeScript what types our useState functions require.
   const emptyRecipeST: RecipeFrontST[] = [];
   const emptyRecipeMTVMH: RecipeMTVMH[] = [];
@@ -61,7 +73,7 @@ export default function StartPage(props) {
   const [standardSearch, setStandardSearch] = useState(searchSettingsBool);
 
   // API Settings, read spoonacular documentation for more info.
-  const defaultSettings = {
+  const devSettings = {
     storedMaxHits: 6,
     storeAddRecipeNutrition: true,
     storedMaxRandomHits: 3,
@@ -69,22 +81,41 @@ export default function StartPage(props) {
     storedIgnorePantry: true,
   };
 
-  if (localStorage.getItem("mightySettings") === null) {
-    localStorage.setItem("mightySettings", JSON.stringify(defaultSettings));
+  const prodSettings = {
+    storedMaxHits: 20,
+    storeAddRecipeNutrition: true,
+    storedMaxRandomHits: 3,
+    storedRanking: 1,
+    storedIgnorePantry: true,
+  };
+
+  if(devMode){
+    if (localStorage.getItem("mightySettings") === null) {
+      localStorage.setItem("mightySettings", JSON.stringify(devSettings));
+    }
+  
+    if (localStorage.getItem("mightyRandomOrStatic") === null) {
+      localStorage.setItem("mightyRandomOrStatic", "true");
+    }
+  } else{
+    if (localStorage.getItem("mightyProdSettings") === null) {
+      localStorage.setItem("mightyProdSettings", JSON.stringify(prodSettings));
+    }
+
+    if (localStorage.getItem("storedProdApiKey") === null) {
+      localStorage.setItem("storedProdApiKey", "6d398aefc8b6440286cd4509f45075c5");
+      setProdApiKey(localStorage.getItem("storedProdApiKey"));
+    }
   }
 
-  if (localStorage.getItem("mightyRandomOrStatic") === null) {
-    localStorage.setItem("mightyRandomOrStatic", "true");
-  }
+  //@ts-ignore
+  const useStatic = devMode ? JSON.parse(localStorage.getItem("mightyRandomOrStatic")) : false;
 
   //@ts-ignore
-  const useStatic = JSON.parse(localStorage.getItem("mightyRandomOrStatic"));
+  const persistedSettings = devMode ? JSON.parse(localStorage.getItem("mightySettings")) : JSON.parse(localStorage.getItem("mightyProdSettings"));
 
   //@ts-ignore
-  const persistedSettings = JSON.parse(localStorage.getItem("mightySettings"));
-
-  //@ts-ignore
-  const apiKey: string | null = useApiCheckerStore((state) => state.apiKey);
+  const apiKey: string | null = devMode ? useApiCheckerStore((state) => state.apiKey) : useApiCheckerStore((state) => state.apiProdKey);
 
   const maxHits: number = persistedSettings.storedMaxHits;
   const addRecipeNutrition: boolean = persistedSettings.storeAddRecipeNutrition;

--- a/src/pages/StartPage/StartPage.tsx
+++ b/src/pages/StartPage/StartPage.tsx
@@ -64,6 +64,10 @@ export default function StartPage(props) {
   // State to shore more button 
   const [showMore, setShowMore] = useState<boolean>(false);
 
+  // variable to determine of no results or not.
+  const [noResultsReturned, setNoResultsReturned] = useState(false);
+
+
   // State to monitor if it's a regular search or MTVMH search, will affect api call string and in turn also the response.
   //@ts-ignore
   const persistedSearchSettings = JSON.parse(sessionStorage.getItem("persisted-search-data"));
@@ -137,6 +141,7 @@ export default function StartPage(props) {
           .then((data) => {
             createCards(data.recipes);
           });
+
       } else {
         // Sample recipes to use instead of calling fetch method during development.
         const forTesting: RecipeFrontST[] = [
@@ -196,6 +201,13 @@ export default function StartPage(props) {
       try {
         const response = await fetch(encodeURI(url));
         const result = await response.json();
+
+        if(result.results.length < 1){
+          setNoResultsReturned(true);
+        } else{
+          setNoResultsReturned(false);
+        }
+        
         createCards(result.results);
       } catch (e) {
         console.log(e);
@@ -210,6 +222,13 @@ export default function StartPage(props) {
         try {
           const response = await fetch(encodeURI(url));
           const result = await response.json();
+
+          if(result.length < 1){
+            setNoResultsReturned(true);
+          } else{
+            setNoResultsReturned(false);
+          }
+
           createCards(result);
         } catch (e) {
           console.log(e);
@@ -453,7 +472,9 @@ export default function StartPage(props) {
             </>}
             </>
           ) : (
-            <NoResult />
+            <>
+              {noResultsReturned && <NoResult />}
+            </>
           )}
         </div>
 


### PR DESCRIPTION
- Startpage should not display No result image now unless actual empty result is returned.
- Recipepage now displays loading if fetch is working until recipe displays. If unsuccessful check API message will show instead.

- Developer function added which is now set to true. If set to false a hardcoded API key will be used. Also some settings are disabled. To try this look in StartPage.tsx at row 26, there is setDevMode(true); 
-Set to false instead to try prod mode. If this works we should then set it to false before pushing to main.